### PR TITLE
Remove tip methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,6 @@ Or if you're working with NPM / ES6:
 ### Chat
 
 - sendMessage(string: message)
-- sendTip(int: amount)
-- sendToy(int: amount)
 - goToGroupChat()
 - requestVIP()
 

--- a/examples/detectnoaudio/tester.js
+++ b/examples/detectnoaudio/tester.js
@@ -15,8 +15,6 @@ var btMute = document.querySelector("#btMute");
 var btUnmute = document.querySelector("#btUnmute");
 var btActivateCam = document.querySelector("#btActivateCam");
 var btDeactivateCam = document.querySelector("#btDeactivateCam");
-var btSendTip100 = document.querySelector("#btSendTip100");
-var btSendToy50 = document.querySelector("#btSendToy50");
 
 var formChat = document.querySelector("#chat-form");
 var input = formChat.querySelector("input");
@@ -112,14 +110,6 @@ btActivateCam.addEventListener("click", function(){
 
 btDeactivateCam.addEventListener("click", function(){
   communicator.deactivateUserCam();
-});
-
-btSendTip100.addEventListener("click", function(){
-  communicator.sendTip(100);
-});
-
-btSendToy50.addEventListener("click", function(){
-  communicator.sendToy(50);
 });
 
 formChat.addEventListener("submit", function(e){

--- a/examples/detectnoaudio/tester.php
+++ b/examples/detectnoaudio/tester.php
@@ -33,9 +33,6 @@ define('URL_API',"YOUR_API_URL");
     <button id="btGoGroupChat">Ir a Group Chat</button>
     <button id="btRequestVIP">Solicitar VIP</button>
     <hr />
-    <button id="btSendTip100">Send tip 100</button>
-    <button id="btSendToy50">Send toy 50</button>
-    <hr />
     <form id="chat-form">
       <input type="text" />
       <button type="submit">Enviar</button>

--- a/examples/lowpowermodeiphone/tester.js
+++ b/examples/lowpowermodeiphone/tester.js
@@ -18,8 +18,6 @@ var btMute = document.querySelector("#btMute");
 var btUnmute = document.querySelector("#btUnmute");
 var btActivateCam = document.querySelector("#btActivateCam");
 var btDeactivateCam = document.querySelector("#btDeactivateCam");
-var btSendTip100 = document.querySelector("#btSendTip100");
-var btSendToy50 = document.querySelector("#btSendToy50");
 var btPlayVideo = document.querySelector("#btPlayVideo");
 
 var formChat = document.querySelector("#chat-form");
@@ -28,7 +26,6 @@ var chatMessages = document.querySelector("#chat-messages");
 var roomModeIndicator = document.querySelector("#roomMode");
 var VIPRequestStatusIndicator = document.querySelector("#VIPRequestStatus");
 var videoStatus = document.querySelector("#videoStatus");
-
 
 // Video events:
 
@@ -112,14 +109,6 @@ btActivateCam.addEventListener("click", function(){
 
 btDeactivateCam.addEventListener("click", function(){
   communicator.deactivateUserCam();
-});
-
-btSendTip100.addEventListener("click", function(){
-  communicator.sendTip(100);
-});
-
-btSendToy50.addEventListener("click", function(){
-  communicator.sendToy(50);
 });
 
 btPlayVideo.addEventListener("click", function(){

--- a/examples/lowpowermodeiphone/tester.php
+++ b/examples/lowpowermodeiphone/tester.php
@@ -33,9 +33,6 @@ define('URL_API',"YOUR_API_URL");
     <button id="btGoGroupChat">Ir a Group Chat</button>
     <button id="btRequestVIP">Solicitar VIP</button>
     <hr />
-    <button id="btSendTip100">Send tip 100</button>
-    <button id="btSendToy50">Send toy 50</button>
-    <hr />
     <form id="chat-form">
       <input type="text" />
       <button type="submit">Enviar</button>

--- a/examples/tester/tester.js
+++ b/examples/tester/tester.js
@@ -14,8 +14,6 @@ var btMute = document.querySelector("#btMute");
 var btUnmute = document.querySelector("#btUnmute");
 var btActivateCam = document.querySelector("#btActivateCam");
 var btDeactivateCam = document.querySelector("#btDeactivateCam");
-var btSendTip100 = document.querySelector("#btSendTip100");
-var btSendToy50 = document.querySelector("#btSendToy50");
 
 var formChat = document.querySelector("#chat-form");
 var input = formChat.querySelector("input");
@@ -103,14 +101,6 @@ btActivateCam.addEventListener("click", function(){
 
 btDeactivateCam.addEventListener("click", function(){
   communicator.deactivateUserCam();
-});
-
-btSendTip100.addEventListener("click", function(){
-  communicator.sendTip(100);
-});
-
-btSendToy50.addEventListener("click", function(){
-  communicator.sendToy(50);
 });
 
 formChat.addEventListener("submit", function(e){

--- a/examples/tester/tester.php
+++ b/examples/tester/tester.php
@@ -32,9 +32,6 @@ define('URL_API',"YOUR_API_URL");
     <button id="btGoGroupChat">Ir a Group Chat</button>
     <button id="btRequestVIP">Solicitar VIP</button>
     <hr />
-    <button id="btSendTip100">Send tip 100</button>
-    <button id="btSendToy50">Send toy 50</button>
-    <hr />
     <form id="chat-form">
       <input type="text" />
       <button type="submit">Enviar</button>

--- a/src/index.js
+++ b/src/index.js
@@ -89,19 +89,6 @@ class Communicator extends EventEmitter {
     value: message,
     sessionToken: this.sessionToken,
   });
-
-  sendTip = amount => sendMessageToChat({
-    type: "externalTip",
-    amount: amount,
-    sessionToken: this.sessionToken,
-  });
-
-  sendToy = amount => sendMessageToChat({
-    type: "externalToy",
-    amount: amount,
-    sessionToken: this.sessionToken,
-  });
-
 }
 
 export {


### PR DESCRIPTION
Elimina los métodos `sendTip` y `sendToy` del código, de la documentación y de los ejemplos.

Cuando se haga la release tendrá que pasar a `2.0.0` ya que si usan estos métodos empezará a fallar, lo apuntaré en las notas de la release como _breaking changes_.