### PR TITLE
Propagate userCamStatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Or if you're working with NPM / ES6:
 ### Common events
 
 - disconnected(string: reason)
+- userCamStatus(string: status)
 
 ## Methods
 

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ class Communicator extends EventEmitter {
       case "onVIPRequestStatusUpdate": this.emit("VIPRequestStatusUpdate", e.data.status); break;
       // Common events:
       case "onDisconnected": this.emit("disconnected", e.data.reason); break;
+      case "onUserCamStatus": this.emit("userCamStatus", e.data.status); break;
     }
   }
 


### PR DESCRIPTION
Propaga el evento `userCamStatus` del nuevo player `v2`, para que puedan mantener un estado con el estado de la webcam